### PR TITLE
update 'uuid' module location in protocol.go

### DIFF
--- a/boxconn/protocol.go
+++ b/boxconn/protocol.go
@@ -2,7 +2,7 @@ package boxconn
 
 import (
 	"bytes"
-	"code.google.com/p/go-uuid/uuid"
+	"github.com/pborman/uuid"
 	"golang.org/x/crypto/nacl/box"
 	"encoding/binary"
 	"fmt"


### PR DESCRIPTION
the uuid module is no longer at code.gogle.com, but has moved to github.com/pborman/uuid.
